### PR TITLE
Active Planting Report sub-tab added to Barn Kit

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/activePlantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/activePlantingReport.html
@@ -1,0 +1,15 @@
+<body>
+    <div id="activePlantingReport">
+        <h1 class="text-center">Active Planting Report</h1>
+        <fieldset class="panel panel-default center-block" style="width: 50%;">
+            <legend class="panel-heading" style="background-color: #d62a17; color: white;">Filters</legend>
+            <div style="display: flex;width: 100%; padding: 7px">
+                
+                <button>Generate Report</button>
+            </div>
+        </fieldset>
+    </div>
+    <script>
+        
+    </script>
+</body>

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/fd2_barn_kit.module
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/fd2_barn_kit.module
@@ -65,6 +65,15 @@ function fd2_barn_kit_menu() {
     'weight' => -60,
   );
 
+  $items['farm/fd2-barn-kit/activePlantingReport'] = array(
+    'title' => 'Active Planting Report',
+    'type' => MENU_LOCAL_TASK,
+    'page callback' => 'fd2_barn_kit_view',
+    'page arguments' => array('activePlantingReport.html'),
+    'access arguments' => array('view fd2 barn kit'),
+    'weight' => -60,
+  );
+
   return $items;
 };
 


### PR DESCRIPTION
__Pull Request Description__

Create a new sub-tab for the Active Planting Report in the Barn Kit Tab

*Completion Criteria* 
- [x] A new sub-tab is created to house the page for the Active Harvest Report

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
